### PR TITLE
Improve row height calculation

### DIFF
--- a/media/js/Scroller.js
+++ b/media/js/Scroller.js
@@ -525,6 +525,7 @@ Scroller.prototype = {
 	"_fnCalcRowHeight": function ()
 	{
 		var
+			nDiv = document.createElement('div'),
 			nTable = this.s.dt.nTable.cloneNode( false ),
 			nBody = document.createElement( 'tbody' ),
 			nTr = document.createElement('tr'),
@@ -534,9 +535,11 @@ Scroller.prototype = {
 		nTr.appendChild( nTd );
 		nBody.appendChild( nTr );
 		nTable.appendChild( nBody );
-		document.body.appendChild( nTable );
+		nDiv.className = this.s.dt.oClasses.sScrollBody;
+		nDiv.appendChild( nTable );
+		document.body.appendChild( nDiv );
 		this.s.rowHeight = $(nTr).height();
-		document.body.removeChild( nTable );
+		document.body.removeChild( nDiv );
 	},
 
 


### PR DESCRIPTION
I mentioned this on http://www.datatables.net/forums/discussion/5458/scroller-issue-tofrom-numbers-wrong/p1 and thought I'd make a pull request for it.

Because there's no "dataTables_scrollBody" div wrapping the test table created by _fnCalcRowHeight(), the styling may be different from the final table, so the row height may be off. This patch adds the div to avoid that problem.
