### PR TITLE
Without the if the plugin assumes that info part of the table has been en

### DIFF
--- a/media/js/Scroller.js
+++ b/media/js/Scroller.js
@@ -665,10 +665,11 @@ Scroller.prototype = {
 		}
 		
 		var n = dt.aanFeatures.i;
-		for ( var i=0, iLen=n.length ; i<iLen ; i++ )
-		{
-			$(n[i]).html( sOut );
-		}
+		if (typeof n != 'undefined')
+			for ( var i=0, iLen=n.length ; i<iLen ; i++ )
+			{
+				$(n[i]).html( sOut );
+			}
 	}
 };
 


### PR DESCRIPTION
Without the if the plugin assumes that info part of the table has been enabled. If info is disabled n will be undefined and referencing n.length will throw an error.
