### PR TITLE
Expanded _fnCalcRowHeight function to fit all scenarios.

### DIFF
--- a/media/js/Scroller.js
+++ b/media/js/Scroller.js
@@ -584,7 +584,9 @@ Scroller.prototype = {
 	"_fnCalcRowHeight": function ()
 	{
 		var
-			nDiv = document.createElement('div'),
+			nWrapperDiv = document.createElement('div');
+			nScrollWrapperDiv = document.createElement('div');
+			nScrollDiv = document.createElement('div');
 			nTable = this.s.dt.nTable.cloneNode( false ),
 			nBody = document.createElement( 'tbody' ),
 			nTr = document.createElement('tr'),
@@ -594,11 +596,15 @@ Scroller.prototype = {
 		nTr.appendChild( nTd );
 		nBody.appendChild( nTr );
 		nTable.appendChild( nBody );
-		nDiv.className = this.s.dt.oClasses.sScrollBody;
-		nDiv.appendChild( nTable );
-		document.body.appendChild( nDiv );
-		this.s.rowHeight = $(nTr).height();
-		document.body.removeChild( nDiv );
+		nWrapperDiv.className = this.s.dt.oClasses.sWrapper;
+		nScrollWrapperDiv.className = this.s.dt.oClasses.sScrollWrapper;
+		nScrollDiv.className = this.s.dt.oClasses.sScrollBody;
+		nScrollDiv.appendChild(nTable);
+		nScrollWrapperDiv.appendChild(nScrollDiv);
+		nWrapperDiv.appendChild(nScrollWrapperDiv);
+		this.s.dt.nTableReinsertBefore.parentElement.appendChild(nWrapperDiv);
+		this.s.rowHeight = $(nTr).outerHeight(true);
+		nWrapperDiv.parentNode.removeChild(nWrapperDiv);
 	},
 
 


### PR DESCRIPTION
Change introduced by kcivey is valid and it solves the problem in his case, but it doesn't fully construct the DOM tree as it would constructed by DataTables and the Scroll plugin. In addition to the div with class contained in oClasses.sScrollBody, divs with classes in oClasses.sWrapper and oClasses.sScrollWrapper have to be created and inserted into the document.

Howver, constructing the full DOM tree doesn't solve the problem when the table is styled via rules that refer to table's ancestors which are not created by DataTables or the Scroller plugin. In order to achieve this, the table with all the wrapper divs has to be inserted in the exact node where it will be inserted by DataTables instead of inserting it into document body. I've used this.s.dt.nTableReinsertBefore in order to find a reference to this node.

Finally, I've made a small change of using jQuqery's outerHeight(true) instead of simply height() in order to take into account any possible margins or borders on tr elements.

I think my code will work in all or at least the great majority of cases.
