### PR TITLE
use sScrollBody class name from options rather than hard-coding

### DIFF
--- a/media/js/Scroller.js
+++ b/media/js/Scroller.js
@@ -359,7 +359,7 @@ Scroller.prototype = {
 		this.dom.force.style.width = "1px";
 		//this.dom.force.style.backgroundColor = "blue";
 
-		this.dom.scroller = $('div.dataTables_scrollBody', this.s.dt.nTableWrapper)[0];
+		this.dom.scroller = $('div.' + this.s.dt.oClasses.sScrollBody, this.s.dt.nTableWrapper)[0];
 		this.dom.scroller.appendChild( this.dom.force );
 		this.dom.scroller.style.position = "relative";
 


### PR DESCRIPTION
I happened to notice this hard-coded class name. The change probably doesn't affect anyone, but just in case someone is using the options to set custom classes, the line should be changed.
