### PR TITLE
Correct end value in the paging info while live scrolling

### DIFF
--- a/media/js/Scroller.js
+++ b/media/js/Scroller.js
@@ -630,6 +630,11 @@ Scroller.prototype = {
 			sTotal = dt.fnFormatNumber( iTotal ),
 			sOut;
 		
+		if(iEnd>iMax){
+			iEnd = iMax;
+			sEnd = dt.fnFormatNumber( iEnd );
+		}
+		
 		if ( dt.fnRecordsDisplay() === 0 && 
 			   dt.fnRecordsDisplay() == dt.fnRecordsTotal() )
 		{


### PR DESCRIPTION
This is to fix the paging info displayed at the bottom of the table while "live" scrolling. If the calculated size of the number of records is higher than the actual number of total records, the displayed info should be fixed to show the correct end value.
