### PR TITLE
Save iScroller to saved scroll position on initialization

### DIFF
--- a/media/js/dataTables.scroller.js
+++ b/media/js/dataTables.scroller.js
@@ -422,8 +422,16 @@ Scroller.prototype = {
 		/* Add a state saving parameter to the DT state saving so we can restore the exact
 		 * position of the scrolling
 		 */
+		var initialStateSave = true;
 		this.s.dt.oApi._fnCallbackReg( this.s.dt, 'aoStateSaveParams', function (oS, oData) {
-			oData.iScroller = that.dom.scroller.scrollTop;
+			/* Set iScroller to saved scroll position on initialization.
+			 */
+			if(initialStateSave && that.s.dt.oLoadedState){
+				oData.iScroller = that.s.dt.oLoadedState.iScroller;
+				initialStateSave = false;
+			} else {
+				oData.iScroller = that.dom.scroller.scrollTop;
+			}
 		}, "Scroller_State" );
 
 		/* Destructor */


### PR DESCRIPTION
When Scroller is loaded, it does the following:

1) Triggers a state save after _fnConstruct.  It saves oData.iScroller = scroller.scrollTop
2) Calls _fnDrawCallback that then restores scroll position by setting scrollTop to oLoadedState.iScroller.
3) Trigger another state save with oData.iScroller = scroller.scrollTop

The problem here is that the scroll position (oData.iScroller) will temporarily be saved as 0 between steps 1 and 3 because scroller.scrollTop will be 0 on init.  If the user happens to reload the page after step 1, but before step 3, the saved scroll position remains at 0 and the actual position gets lost.  This results in a table with empty white space.

The fix is to set iScroller to saved scroll position on  initialization.

Thanks!
