### PR TITLE
If datatable rows have some CSS style applied that depends on the table ...

### DIFF
--- a/js/dataTables.scroller.js
+++ b/js/dataTables.scroller.js
@@ -850,9 +850,18 @@ Scroller.prototype = /** @lends Scroller.prototype */{
 
 		$('div.'+this.s.dt.oClasses.sScrollBody, container).append( nTable );
 
-		this.s.dt.nHolding.replaceWith(container);
+		if(this.s.dt.nTableWrapper.parent().length) {
+			container.insertBefore(this.s.dt.nTableWrapper);
+		} else if(this.s.dt.nHolding) {
+			this.s.dt.nHolding.replaceWith(container);
+		} else {
+			container.appendTo('body');
+		}
 		this.s.heights.row = $('tr', tbody).eq(1).outerHeight();
-		container.replaceWith(this.s.dt.nHolding).remove();
+		if(this.s.dt.nHolding) {
+			container.replaceWith(this.s.dt.nHolding);
+		}
+		container.remove();
 	},
 
 


### PR DESCRIPTION
...tag ancestors it won't influence measured row height properly if the cloned table is attached to the top level node (body)

Depends on: https://github.com/DataTables/DataTables/pull/287
