### PR TITLE
Makes dataTables.scroller work with DataTables 1.9.x.

### DIFF
--- a/js/dataTables.scroller.js
+++ b/js/dataTables.scroller.js
@@ -857,10 +857,17 @@ Scroller.prototype = /** @lends Scroller.prototype */{
 
 		$('div.'+dt.oClasses.sScrollBody, container).append( nTable );
 
-		container.appendTo( dt._bInitComplete ?
-			origTable.parentNode :
-			dt.nHolding
-		);
+		var appendTo;
+		if (dt._bInitComplete) {
+			appendTo = origTable.parentNode;
+		} else {
+			if (!this.s.dt.nHolding) {
+				this.s.dt.nHolding = $( '<div></div>' ).insertBefore( this.s.dt.nTable );
+			}
+			appendTo = this.s.dt.nHolding;
+		}
+
+		container.appendTo( appendTo );
 		this.s.heights.row = $('tr', tbody).eq(1).outerHeight();
 		container.remove();
 	},


### PR DESCRIPTION
This fixes #22, but I am not sure if its "correct" since it creates the nHolding element which is a non-accessible element in 1.9.4.
I'll change it around based on your comments no problem.
