### PR TITLE
Allow fnScrollToRow to notify caller of when it completes

### DIFF
--- a/js/dataTables.scroller.js
+++ b/js/dataTables.scroller.js
@@ -362,7 +362,7 @@ Scroller.prototype = /** @lends Scroller.prototype */{
 		}
 		else
 		{
-		    $(this.dom.scroller).scrollTop(px);
+		    $(this.dom.scroller).scrollTop( px );
 		    dfd.resolve();
 		}
 

--- a/js/dataTables.scroller.js
+++ b/js/dataTables.scroller.js
@@ -324,6 +324,8 @@ Scroller.prototype = /** @lends Scroller.prototype */{
 	 */
 	"fnScrollToRow": function ( iRow, bAnimate )
 	{
+	    var dfd = $.Deferred();
+
 		var that = this;
 		var ani = false;
 		var px = this.fnRowToPixels( iRow );
@@ -353,14 +355,18 @@ Scroller.prototype = /** @lends Scroller.prototype */{
 				// This needs to happen after the animation has completed and
 				// the final scroll event fired
 				setTimeout( function () {
-					that.s.ani = false;
+				    that.s.ani = false;
+				    dfd.resolve();
 				}, 0 );
 			} );
 		}
 		else
 		{
-			$(this.dom.scroller).scrollTop( px );
+		    $(this.dom.scroller).scrollTop(px);
+		    dfd.resolve();
 		}
+
+		return dfd.promise();
 	},
 
 


### PR DESCRIPTION
When you use animation mode, the calling function cannot be sure of when the scroll has finished, which we found to be a requirement for our code. Sharing the change we made since we found it useful.