### PR TITLE
Stability improvement

### DIFF
--- a/js/dataTables.scroller.js
+++ b/js/dataTables.scroller.js
@@ -668,7 +668,11 @@ $.extend( Scroller.prototype, {
 				this.s.topRowFloat = this.fnPixelsToRow( iScrollTop, false );
 			}
 
-			if ( iTopRow <= 0 ) {
+			if ( !isFinite(this.s.topRowFloat) ) {
+				this.s.topRowFloat = 0;
+			}
+
+			if ( !isFinite(iTopRow) || iTopRow <= 0 ) {
 				/* At the start of the table */
 				iTopRow = 0;
 			}


### PR DESCRIPTION
Resolves issue with NaN appearing in the table information display.
Resolves issue with the scroller position jumping to the top while scrolling. May be related to https://github.com/DataTables/Scroller/issues/56