### PR TITLE
Fix: improve height measurement

### DIFF
--- a/js/dataTables.scroller.js
+++ b/js/dataTables.scroller.js
@@ -441,11 +441,13 @@ $.extend( Scroller.prototype, {
 		var heights = this.s.heights;
 
 		if ( heights.row ) {
-			heights.viewport = $(this.dom.scroller).height();
+			heights.viewport = $.contains(document, this.dom.scroller) ?
+				$(this.dom.scroller).height() :
+				this._parseHeight($(this.dom.scroller).css('height'));
 
 			// If collapsed (no height) use the max-height parameter
 			if ( ! heights.viewport ) {
-				heights.viewport = 1*$(this.dom.scroller).css('max-height').replace('px', '');
+				heights.viewport = this._parseHeight($(this.dom.scroller).css('max-height'));
 			}
 
 			this.s.viewportRows = parseInt( heights.viewport / heights.row, 10 )+1;
@@ -799,6 +801,45 @@ $.extend( Scroller.prototype, {
 					(yMax*2) - (val * val * coeff);
 			}
 		}
+	},
+
+	/**
+	 * Parse CSS height property string as number
+	 *
+	 * An attempt is made to parse the string as a number. Currently supported units are 'px',
+	 * 'vh', and 'rem'. 'em' is partially supported; it works as long as the parent element's
+	 * font size matches the body element. Zero is returned for unrecognized strings.
+	 *  @param {string} cssHeight CSS height property string
+	 *  @returns {number} height
+	 *  @private
+	 */
+	_parseHeight: function(cssHeight) {
+		var height;
+		var matches = /^([+-]?(?:\d+(?:\.\d+)?|\.\d+))(px|em|rem|vh)$/.exec(cssHeight);
+
+		if (matches === null) {
+			return 0;
+		}
+
+		var value = parseFloat(matches[1]);
+		var unit = matches[2];
+
+		if ( unit === 'px' ) {
+			height = value;
+		}
+		else if ( unit === 'vh' ) {
+			height = ( value / 100 ) * $(window).height();
+		}
+		else if ( unit === 'rem' ) {
+			height = value * parseFloat($(':root').css('font-size'));
+		}
+		else if ( unit === 'em' ) {
+			height = value * parseFloat($('body').css('font-size'));
+		}
+
+		return height ?
+			height :
+			0;
 	},
 
 


### PR DESCRIPTION
This improves the height measurement when deriving from a string value.
Previously it would work correctly only with pixels, now it also works
with units 'vh' and 'rem'.

Relates to issue #33.

Let me know if there's anything that could be improved - I tried to follow the conventions used elsewhere in the file, but it's likely I missed something.