### PR TITLE
Fix: don't reset scroll position when table is redrawn with "full-hold"

### DIFF
--- a/js/dataTables.scroller.js
+++ b/js/dataTables.scroller.js
@@ -871,7 +871,7 @@ $.extend( Scroller.prototype, {
 		this.s.skip = true;
 
 		// If paging is reset
-		if ( (this.s.dt.bSorted || this.s.dt.bFiltered) && displayStart === 0 ) {
+		if ( (this.s.dt.bSorted || this.s.dt.bFiltered) && displayStart === 0 && !this.s.dt._drawHold ) {
 			this.s.topRowFloat = 0;
 		}
 


### PR DESCRIPTION
Commit c8d42bb7c3e86e7432d98a9bdd02c2cd81e6b723 introduced a bug that caused Scroller to reset the scroll position even when the table was redrawn with "full-hold" mode, i.e. `table.draw("full-hold")` or `table.draw(false)`. This commit should fix that :)