### PR TITLE
Fixed row height calculation for tables with only one row.

### DIFF
--- a/js/dataTables.scroller.js
+++ b/js/dataTables.scroller.js
@@ -1025,9 +1025,16 @@ $.extend( Scroller.prototype, {
 		// Want 3 rows in the sizing table so :first-child and :last-child
 		// CSS styles don't come into play - take the size of the middle row
 		$('tbody tr:lt(4)', origTable).clone().appendTo( tbody );
-		while( $('tr', tbody).length < 3 ) {
-			tbody.append( '<tr><td>&nbsp;</td></tr>' );
-		}
+        var rowsCount = $('tr', tbody).length;
+
+        if (rowsCount == 1) {
+            tbody.prepend('<tr><td>&nbsp;</td></tr>');
+            tbody.append('<tr><td>&nbsp;</td></tr>');
+        } else {
+            for (; rowsCount < 3; rowsCount++) {
+                tbody.append('<tr><td>&nbsp;</td></tr>');
+            }
+        }
 
 		$('div.'+dt.oClasses.sScrollBody, container).append( nTable );
 


### PR DESCRIPTION
If table has some dynamic content on row (in my case, it was a button, inserted inside 'render' event) and data has only one record, height of row calculates wrong way. Sorry for spaces instead of tabs. Saw your tabs on github after push.