### PR TITLE
Keep the label in position once it is shown

### DIFF
--- a/js/dataTables.scroller.js
+++ b/js/dataTables.scroller.js
@@ -521,6 +521,7 @@ $.extend( Scroller.prototype, {
 				that.s.mousedown = true;
 			})
 			.on('mouseup.dt-scroller', function () {
+				that.s.labelVisible = false;
 				that.s.mouseup = false;
 				that.dom.label.css('display', 'none');
 			});
@@ -1063,6 +1064,9 @@ $.extend( Scroller.prototype, {
 		this.s.stateSaveThrottle();
 
 		if ( this.s.scrollType === 'jump' && this.s.mousedown ) {
+			this.s.labelVisible = true;
+		}
+		if (this.s.labelVisible) {
 			this.dom.label
 				.html( this.s.dt.fnFormatNumber( parseInt( this.s.topRowFloat, 10 )+1 ) )
 				.css( 'top', iScrollTop + (iScrollTop * heights.labelFactor ) )

--- a/js/dataTables.scroller.js
+++ b/js/dataTables.scroller.js
@@ -522,7 +522,7 @@ $.extend( Scroller.prototype, {
 			})
 			.on('mouseup.dt-scroller', function () {
 				that.s.labelVisible = false;
-				that.s.mouseup = false;
+				that.s.mousedown = false;
 				that.dom.label.css('display', 'none');
 			});
 


### PR DESCRIPTION
When the scroller has a few rows it is possible to perform a jump scroll followed by some cont scrolls. In this situation the label keeps anchored inside the scrolled div to the last position where the jump happened.

Keeping the visibility status we can adjust the position of the label also in the following cont scrolls.