### PR TITLE
`mousedown` flag set to true but never reset

### DIFF
--- a/js/dataTables.scroller.js
+++ b/js/dataTables.scroller.js
@@ -522,7 +522,6 @@ $.extend( Scroller.prototype, {
 			})
 			.on('mouseup.dt-scroller', function () {
 				that.s.mousedown = false;
-				that.s.mouseup = false;
 				that.dom.label.css('display', 'none');
 			});
 

--- a/js/dataTables.scroller.js
+++ b/js/dataTables.scroller.js
@@ -521,6 +521,7 @@ $.extend( Scroller.prototype, {
 				that.s.mousedown = true;
 			})
 			.on('mouseup.dt-scroller', function () {
+				that.s.mousedown = false;
 				that.s.mouseup = false;
 				that.dom.label.css('display', 'none');
 			});


### PR DESCRIPTION
When using scroller within a searchpane, there's a label displayed at the bottom of the pane (completely at the bottom, not following the scroller like it should be in standard table). 

The annoying thing is that this label remains displayed even when stopping scrolling and displays a number which represents nothing to the user. 

This change at least stops it from being updated continuously, which is completely useless as the label is displayed at the complete bottom of the search pane. 

IMO there should also be an option within the scroller extension to disable this label completely and I could provide a quick PR if desired.