### PR TITLE
Add a new option to Scroller (displayLabel)

### DIFF
--- a/docs/option/scroller.displayLabel.xml
+++ b/docs/option/scroller.displayLabel.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<dt-option library="Scroller">
+	<name>scroller.displayLabel</name>
+	<summary>Display a label while user is scrolling with the scrollbar</summary>
+
+	<type type="boolean">
+		<description>
+			* `true` show the label when scrolling
+			* `false` do not show
+		</description>
+	</type>
+
+	<default value="true">
+		Label is displayed when scrolling using the scrollbar
+	</default>
+
+	<description>
+	  While scrolling using the scrollbar, a label is displayed to indicate the user the approximate position displayed within the whole dataset
+  </description>
+
+	<example title="Do not display label when scrolling using scrollbar"><![CDATA[
+
+$('#example').DataTable( {
+	scrollY: true,
+	scroller: {
+		displayLabel: false
+	}
+} );
+
+]]></example>
+
+</dt-option>

--- a/js/dataTables.scroller.js
+++ b/js/dataTables.scroller.js
@@ -299,8 +299,11 @@ $.extend( Scroller.prototype, {
 			this.s.dt._iDisplayLength = this.s.viewportRows * this.s.displayBuffer;
 		}
 
-		var label = this.dom.label.outerHeight();
-		heights.labelFactor = (heights.viewport-label) / heights.scroll;
+    if(this.s.displayLabel)
+    {
+      var label = this.dom.label.outerHeight();
+      heights.labelFactor = (heights.viewport-label) / heights.scroll;
+    }
 
 		if ( redraw === undefined || redraw )
 		{
@@ -490,7 +493,10 @@ $.extend( Scroller.prototype, {
 				.append( this.dom.loader );
 		}
 
-		this.dom.label.appendTo(this.dom.scroller);
+    if(this.s.displayLabel)
+    {
+      this.dom.label.appendTo(this.dom.scroller);
+    }
 
 		/* Initial size calculations */
 		if ( this.s.heights.row && this.s.heights.row != 'auto' )
@@ -521,10 +527,13 @@ $.extend( Scroller.prototype, {
 				that.s.mousedown = true;
 			})
 			.on('mouseup.dt-scroller', function () {
-				that.s.labelVisible = false;
-				that.s.mousedown = false;
-				that.dom.label.css('display', 'none');
-			});
+        that.s.mousedown = false;
+        if (this.s.displayLabel)
+        {
+          that.s.labelVisible = false;
+          that.dom.label.css('display', 'none');
+        }
+      });
 
 		// On resize, update the information element, since the number of rows shown might change
 		$(window).on( 'resize.dt-scroller', function () {
@@ -1063,7 +1072,7 @@ $.extend( Scroller.prototype, {
 		this.s.lastScrollTop = iScrollTop;
 		this.s.stateSaveThrottle();
 
-		if ( this.s.scrollType === 'jump' && this.s.mousedown ) {
+		if ( this.s.scrollType === 'jump' && this.s.mousedown && this.s.displayLabel) {
 			this.s.labelVisible = true;
 		}
 		if (this.s.labelVisible) {
@@ -1174,7 +1183,16 @@ Scroller.defaults = {
 	 *  @default  200
 	 *  @static
 	 */
-	serverWait: 200
+  serverWait: 200,
+  
+  /**
+	 *  While scrolling using the scrollbar, a label is displayed to indicate the user 
+	 *  the approximate position displayed within the whole table content
+	 *  @type     bool
+	 *  @default  true
+	 *  @static
+	 */
+  displayLabel: true
 };
 
 Scroller.oDefaults = Scroller.defaults;


### PR DESCRIPTION
Add a new initialization option for Scroller to let the user decide if he wants a label to be displayed when scrolling using the scrollbar (the black label floating left of the pointer). I mention "using the scrollbar" as the label update is (and was already) bound to the `mousedown` event so that doesn't change for now.