### PR TITLE
allow for the first row not to be split

### DIFF
--- a/js/dataTables.scroller.js
+++ b/js/dataTables.scroller.js
@@ -82,7 +82,7 @@ var DataTable = $.fn.dataTable;
  *  @constructor
  *  @global
  *  @param {object} dt DataTables settings object or API instance
- *  @param {object} [opts={}] Configuration object for Scroller. Options 
+ *  @param {object} [opts={}] Configuration object for Scroller. Options
  *    are defined by {@link Scroller.defaults}
  *
  *  @requires jQuery 1.7+
@@ -296,7 +296,7 @@ $.extend( Scroller.prototype, {
 		}
 
 		var label = this.dom.label.outerHeight();
-		
+
 		heights.xbar = this.dom.scroller.offsetHeight - this.dom.scroller.clientHeight;
 		heights.labelHeight = label;
 
@@ -318,7 +318,7 @@ $.extend( Scroller.prototype, {
 	*/
 	pageInfo: function()
 	{
-		var 
+		var
 			dt = this.s.dt,
 			iScrollTop = this.dom.scroller.scrollTop,
 			iTotal = dt.fnRecordsDisplay(),
@@ -558,7 +558,7 @@ $.extend( Scroller.prototype, {
 		}
 
 		this.measure( false );
-	
+
 		that.s.stateSaveThrottle = that.s.dt.oApi._fnThrottle( function () {
 			that.s.dtApi.state.save();
 		}, 500 );
@@ -639,7 +639,7 @@ $.extend( Scroller.prototype, {
                 tbody.append('<tr><td>&#160;</td></tr>');
             }
 		}
-	
+
 		$('div.'+dt.oClasses.sScrollBody, container).append( nTable );
 
 		// If initialised using `dom`, use the holding element as the insert point
@@ -654,6 +654,9 @@ $.extend( Scroller.prototype, {
 
 		container.appendTo( insertEl );
 		this.s.heights.row = $('tr', tbody).eq(1).outerHeight();
+		if (!this.s.allowFirstRowSplit) {
+			this.s.heights.row = $('tr', tbody).eq(1)[0].getBoundingClientRect().height;
+		}
 
 		container.remove();
 	},
@@ -695,6 +698,9 @@ $.extend( Scroller.prototype, {
 
 		// Position the table in the virtual scroller
 		var tableTop = iScrollTop - ((this.s.topRowFloat - displayStart) * heights.row);
+		if (!this.s.allowFirstRowSplit) {
+			tableTop = iScrollTop + (iScrollTop % heights.row) - (this.s.topRowFloat - displayStart) * heights.row;
+		}
 		if ( displayStart === 0 ) {
 			tableTop = 0;
 		}
@@ -772,7 +778,7 @@ $.extend( Scroller.prototype, {
 	 * had scrolling containers of infinite height (i.e. the absolute value)
 	 *
 	 *  @param {string} dir Domain transform direction, `virtualToPhysical` or
-	 *    `physicalToVirtual` 
+	 *    `physicalToVirtual`
 	 *  @returns {number} Calculated transform
 	 *  @private
 	 */
@@ -945,6 +951,24 @@ $.extend( Scroller.prototype, {
 			0;
 	},
 
+	_updateTableTop: function (displayStart) {
+		var that = this,
+			heights = this.s.heights,
+			iScrollTop = this.dom.scroller.scrollTop,
+			dispStart = displayStart < 0 ? 0 : displayStart;
+
+		if (this.s.allowFirstRowSplit) {
+			return;
+		}
+
+		this.s.topRowFloat = this.pixelsToRow( iScrollTop, false, true );
+		var tableTop = iScrollTop + (iScrollTop % heights.row) - (this.s.topRowFloat - dispStart) * heights.row;
+		setTimeout(function () {
+			that.dom.table.style.top = tableTop + 'px';
+		}, 0);
+	},
+
+
 	/**
 	 * Scrolling function - fired whenever the scrolling position is changed.
 	 * This method needs to use the stored values to see if the table should be
@@ -962,17 +986,11 @@ $.extend( Scroller.prototype, {
 			iScrollTop = this.dom.scroller.scrollTop,
 			iTopRow;
 
-		if ( this.s.skip ) {
+		if ( this.s.skip || this.s.ingnoreScroll || (iScrollTop === this.s.lastScrollTop)) {
+			this._updateTableTop(this.s.dt._iDisplayStart);
 			return;
 		}
 
-		if ( this.s.ingnoreScroll ) {
-			return;
-		}
-
-		if ( iScrollTop === this.s.lastScrollTop ) {
-			return;
-		}
 
 		/* If the table has been sorted or filtered, then we use the redraw that
 		 * DataTables as done, rather than performing our own
@@ -1045,6 +1063,7 @@ $.extend( Scroller.prototype, {
 				var draw = function () {
 					that.s.dt._iDisplayStart = that.s.targetTop;
 					that.s.dt.oApi._fnDraw( that.s.dt );
+					that._updateTableTop(that.s.dt._iDisplayStart);
 				};
 
 				/* Do the DataTables redraw based on the calculated start point - note that when
@@ -1064,10 +1083,13 @@ $.extend( Scroller.prototype, {
 					this.dom.loader.css( 'display', 'block' );
 					this.s.loaderVisible = true;
 				}
+			} else {
+				this._updateTableTop(this.s.dt._iDisplayStart - 1);
 			}
 		}
 		else {
 			this.s.topRowFloat = this.pixelsToRow( iScrollTop, false, true );
+			this._updateTableTop(this.s.dt._iDisplayStart - 1);
 		}
 
 		this.s.lastScrollTop = iScrollTop;
@@ -1186,7 +1208,15 @@ Scroller.defaults = {
 	 *  @default  200
 	 *  @static
 	 */
-	serverWait: 200
+	serverWait: 200,
+
+	/**
+	 * Allow (or not) for the first row to appear as a whole
+	 *  @type     boolean
+	 *  @default  true
+	 *  @static
+	 */
+	allowFirstRowSplit: true
 };
 
 Scroller.oDefaults = Scroller.defaults;


### PR DESCRIPTION
Hi. 
My incentive was to add the ability to mimic what `scroll-snap-type: y mandatory;` does
That is that the first visible row is always shown as a whole.

This PR introduces an new parameter to allow this new display mode.
Thanks in advance for your time.
