### PR TITLE
Fix issue with empty space when server-side data is updated concurrently

### DIFF
--- a/js/dataTables.scroller.js
+++ b/js/dataTables.scroller.js
@@ -674,7 +674,8 @@ $.extend( Scroller.prototype, {
 			iTableHeight = $(this.s.dt.nTable).height(),
 			displayStart = this.s.dt._iDisplayStart,
 			displayLen = this.s.dt._iDisplayLength,
-			displayEnd = this.s.dt.fnRecordsDisplay();
+			displayEnd = this.s.dt.fnRecordsDisplay(),
+			viewportEndY = iScrollTop + heights.viewport;
 
 		// Disable the scroll event listener while we are updating the DOM
 		this.s.skip = true;
@@ -700,6 +701,17 @@ $.extend( Scroller.prototype, {
 		}
 		else if ( displayStart + displayLen >= displayEnd ) {
 			tableTop = heights.scroll - iTableHeight;
+		}
+		else {
+			var iTableBottomY = tableTop + iTableHeight;
+			if (iTableBottomY < viewportEndY) {
+				// The last row of the data is above the end of the viewport.
+				// This means the background is visible, which is not what the user expects.
+				var newTableTop = viewportEndY - iTableHeight;
+				var diffPx = newTableTop - tableTop;
+				this.s.baseScrollTop += diffPx + 1; // Update start row number in footer.
+				tableTop = newTableTop; // Move table so last line of data is at the bottom of the viewport.
+			}
 		}
 
 		this.dom.table.style.top = tableTop+'px';


### PR DESCRIPTION
When using Scroller to show server-side data that is concurrently updated, calling scroller.toPosition() may result in a situation where there are multiple blank lines below the rows of the Datatable. This happens because first, the Datatable is initialized using data from the backend, indicating a total number of lines X. Then we jump to line X - pageSize, triggering a draw and using fresh data from the backend. Meanwhile, though, new data has arrived so the total number of lines to show has increased. This new line count is used to position the table in the viewport, leading to an unpleasant visual.
The patch fixes this by checking if the rendered table ends above the bottom border of the viewport and updating positions so the bottom borders of the table and the viewport match.
This commit does not seem to suffer from the display issue at the top of tables like the previous attempt to fix the bug.
And, yes, MIT license is okay for me :-)